### PR TITLE
fix: Update statuses after step or test creation

### DIFF
--- a/src/lib/operators/useTest.ts
+++ b/src/lib/operators/useTest.ts
@@ -36,9 +36,11 @@ export function useTest(
         );
         const testCase = project?.testCases.find((item) => item.id === caseId);
         const test = testCase?.tests.find((test) => test.id === testId);
-        if (!test || !project) {
+
+        if (!test || !testCase || !project) {
           return;
         }
+
         test.steps.push({
           ...values,
           id: crypto.randomUUID(),
@@ -47,6 +49,9 @@ export function useTest(
           createdAt: date.getTime(),
         });
         test.lastUpdate = project.lastUpdate = date.getTime();
+
+        computeStatus(test, test.steps);
+        computeStatus(testCase, testCase.tests);
       });
     },
     [projectId, caseId, testId, changeDoc],

--- a/src/lib/operators/useTestCase.ts
+++ b/src/lib/operators/useTestCase.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import { useDocContext } from "../../components/docContext/DocContext";
 import { StatusEnum, TComment, TDocType } from "../../types/schema";
 import { addTuples } from "../helpers/addTuples";
+import { computeStatus } from "../helpers/computeStatus.ts";
 import { removeTuples } from "../helpers/removeTuples";
 import { TOperatorLoaderStatus, TUseTestCase } from "./types";
 
@@ -33,15 +34,20 @@ export function useTestCase(
           (item) => projectId && item.id === projectId,
         );
         const testCase = project?.testCases.find((item) => item.id === caseId);
-        if (!project) {
+
+        if (!project || !testCase) {
           return;
         }
+
         /**@hribeiro TODO: The next line was introduced to keep compatibility with older projects. To be removed*/
         if (!project.collaboratorToTest) project.collaboratorToTest = [];
+
         values.tags.forEach((tag) => project.tagToTest?.push([tag, testId]));
+
         values.assignees.forEach((assigneeId) =>
           project.collaboratorToTest?.push([assigneeId, testId]),
         );
+
         testCase?.tests.push({
           title: values.title,
           description: values.description,
@@ -51,6 +57,8 @@ export function useTestCase(
           status: StatusEnum.PENDING,
           steps: [],
         });
+
+        computeStatus(testCase, testCase.tests);
       });
     },
     [projectId, caseId, changeDoc],


### PR DESCRIPTION
- After a `step` is created, update both `test` and `testCase` status to reflect the change 
- After a `test` is created, update `testCase` status to reflect the change

Closes #110