### PR TITLE
Add Tooltip with help on EditableText and SimpleNewElementForm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ release
 k8s-deployment.yaml
 k8s-ingress.yaml
 k8s-service.yaml
+
+.vite

--- a/src/components/shared/EditableText.tsx
+++ b/src/components/shared/EditableText.tsx
@@ -1,4 +1,4 @@
-import { Box, Input, Title, TitleProps } from "@mantine/core";
+import { Box, Input, Title, TitleProps, Tooltip } from "@mantine/core";
 import { useClickOutside, useDisclosure } from "@mantine/hooks";
 import { useEffect, useState } from "react";
 
@@ -55,12 +55,19 @@ export const EditableTitle: React.FC<EditableTitle> = ({
   if (editing) {
     return (
       <Box ref={ref} onBlur={onBlur} flex={1}>
-        <Input
-          value={internalValue}
-          onChange={onTextInputChange}
-          onKeyDown={onKeyDown}
-          autoFocus
-        />
+        <Tooltip
+          label="Press Enter to save, Esc to undo"
+          position="bottom-start"
+          events={{ hover: false, focus: true, touch: false }}
+          withArrow
+        >
+          <Input
+            value={internalValue}
+            onChange={onTextInputChange}
+            onKeyDown={onKeyDown}
+            autoFocus
+          />
+        </Tooltip>
       </Box>
     );
   }

--- a/src/components/shared/SimpleNewElementForm.tsx
+++ b/src/components/shared/SimpleNewElementForm.tsx
@@ -1,4 +1,4 @@
-import { Box, TextInput } from "@mantine/core";
+import { Box, TextInput, Tooltip } from "@mantine/core";
 import { isNotEmpty, useForm } from "@mantine/form";
 import { useClickOutside } from "@mantine/hooks";
 import { useEffect } from "react";
@@ -72,15 +72,22 @@ export const SimpleNewElementForm = ({
   return (
     <Box ref={ref}>
       <form onSubmit={form.onSubmit(handleSubmit)}>
-        <TextInput
-          w={"100%"}
-          required
-          autoFocus
-          {...form.getInputProps("title")}
-          onBlur={onBlur}
-          onKeyDown={onKeyDown}
-          placeholder={placeholder}
-        />
+        <Tooltip
+          label="Press Enter to save, Esc to undo"
+          position="bottom-start"
+          events={{ hover: false, focus: true, touch: false }}
+          withArrow
+        >
+          <TextInput
+            w={"100%"}
+            required
+            autoFocus
+            {...form.getInputProps("title")}
+            onBlur={onBlur}
+            onKeyDown={onKeyDown}
+            placeholder={placeholder}
+          />
+        </Tooltip>
       </form>
     </Box>
   );


### PR DESCRIPTION
Closes #156

Also adds `.vite` folder to `.gitignore` and fixes error in tag nesting  (`div` cannot be a descendant of `p`, because `<Text>` outputs a paragraph if not set otherwise)