### PR TITLE
Timeline view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ release
 k8s-deployment.yaml
 k8s-ingress.yaml
 k8s-service.yaml
+
+.vite

--- a/src/components/CollaboratorAnchor/CollaboratorAnchor.tsx
+++ b/src/components/CollaboratorAnchor/CollaboratorAnchor.tsx
@@ -1,0 +1,128 @@
+import {
+  Anchor,
+  AnchorProps,
+  Group,
+  GroupProps,
+  HoverCard,
+  HoverCardDropdownProps,
+  HoverCardProps,
+  HoverCardTargetProps,
+  Stack,
+  Text,
+  TextProps,
+} from "@mantine/core";
+import { MouseEvent, ReactNode, useCallback } from "react";
+import { USER_ANONYMOUS } from "../../lib/constants/generic.ts";
+import { TCollaborator } from "../../types/schema.ts";
+import { CollaboratorAvatar } from "../CollaboratorAvatar/CollaboratorAvatar.tsx";
+import { InlineFlex } from "../InlineFlex/InlineFlex.tsx";
+
+interface CollaboratorAnchorProps extends HoverCardProps {
+  collaborator?: TCollaborator;
+  secondaryInfo?: string | ReactNode;
+  targetProps?: Partial<HoverCardTargetProps>;
+  dropdownProps?: Partial<HoverCardDropdownProps>;
+  anchorProps?: Partial<AnchorProps>;
+  secondaryInfoProps?: Partial<TextProps>;
+  hoverCardGroupProps?: Partial<GroupProps>;
+  withHoverCard?: boolean;
+  withInlineAvatar?: boolean;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+}
+
+/**
+ * Displays a collaborator's name as an anchor.
+ * It can optionally show an inline avatar and a hover card with more details about the collaborator.
+ *
+ * @param {TCollaborator} [collaborator] - The collaborator data to display. If not provided, defaults to an anonymous user.
+ * @param {Partial<AnchorProps>} [anchorProps] - Props for the anchor element.
+ *
+ * @param {boolean} [withInlineAvatar=false] - Whether to show the avatar inline with the name.
+ * @param {boolean} [withHoverCard=false] - Whether to show the hover card.
+ *
+ * @param {HoverCardProps} [hoverCardProps] - Additional props for the hover card.
+ * @param {Partial<GroupProps>} [hoverCardGroupProps] - Props for the group inside the hover card.
+ * @param {Partial<HoverCardTargetProps>} [targetProps] - Props for the hover card target.
+ * @param {Partial<HoverCardDropdownProps>} [dropdownProps] - Props for the hover card dropdown.
+ *
+ * @param {string | ReactNode} [secondaryInfo] - Optional secondary information to show.
+ * @param {Partial<TextProps>} [secondaryInfoProps] - Props for the secondary info text.
+ *
+ * @returns {JSX.Element} The rendered collaborator anchor component.
+ */
+export const CollaboratorAnchor = ({
+  anchorProps = {},
+  collaborator,
+  dropdownProps = {},
+  hoverCardGroupProps = {},
+  secondaryInfo,
+  secondaryInfoProps = {},
+  targetProps = {},
+  withHoverCard = false,
+  withInlineAvatar = false,
+  onClick,
+  ...hoverCardProps
+}: CollaboratorAnchorProps) => {
+  let secondaryInfoElement = null;
+
+  if (secondaryInfo) {
+    if (typeof secondaryInfo === "string") {
+      secondaryInfoElement = (
+        <Text span inline c="dimmed" size="sm" {...secondaryInfoProps}>
+          {secondaryInfo}
+        </Text>
+      );
+    } else {
+      secondaryInfoElement = secondaryInfo;
+    }
+  }
+
+  const clickHandler = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      if (onClick) {
+        onClick(event);
+      }
+    },
+    [onClick],
+  );
+
+  return (
+    <HoverCard
+      middlewares={{ inline: true }}
+      withArrow
+      position="top"
+      radius="md"
+      openDelay={200}
+      closeDelay={400}
+      disabled={withHoverCard === false}
+      {...hoverCardProps}
+    >
+      <HoverCard.Target {...targetProps}>
+        <Anchor onClick={clickHandler} {...anchorProps}>
+          <InlineFlex>
+            {withInlineAvatar ? (
+              <CollaboratorAvatar
+                collaborator={collaborator}
+                size={25}
+                withTooltip={false}
+              />
+            ) : null}
+            {collaborator?.name ?? USER_ANONYMOUS.name}
+          </InlineFlex>
+        </Anchor>
+      </HoverCard.Target>
+      <HoverCard.Dropdown {...dropdownProps}>
+        <Group gap="md" align="center" wrap="nowrap" {...hoverCardGroupProps}>
+          <CollaboratorAvatar collaborator={collaborator} />
+
+          <Stack gap={4}>
+            <Text span inline fw="bold">
+              {collaborator?.name ?? USER_ANONYMOUS.name}
+            </Text>
+            {secondaryInfoElement}
+          </Stack>
+        </Group>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+};

--- a/src/components/CollaboratorAvatar/CollaboratorAvatar.tsx
+++ b/src/components/CollaboratorAvatar/CollaboratorAvatar.tsx
@@ -1,0 +1,41 @@
+import { Avatar, AvatarProps } from "@mantine/core";
+import { USER_ANONYMOUS } from "../../lib/constants/generic.ts";
+import { TCollaborator } from "../../types/schema.ts";
+import { Avatars } from "../avatars/Avatars.tsx";
+
+interface CollaboratorAvatarProps extends AvatarProps {
+  collaborator?: TCollaborator;
+  withTooltip?: boolean;
+}
+
+/**
+ * Renders an avatar for a collaborator.
+ * If a collaborator is provided, shows their avatar with optional tooltip.
+ * Otherwise, displays a default anonymous user avatar.
+ *
+ * @param collaborator - The collaborator data.
+ * @param withTooltip - Whether to show a tooltip on the avatar.
+ * @param avatarProps - Additional props for the Avatar component.
+ */
+export const CollaboratorAvatar = ({
+  collaborator,
+  withTooltip = true,
+  ...avatarProps
+}: CollaboratorAvatarProps) => {
+  if (collaborator) {
+    return (
+      <Avatars
+        collaborators={[collaborator]}
+        maxAvatars={1}
+        avatarProps={avatarProps}
+        withTooltip={withTooltip}
+      />
+    );
+  }
+
+  return (
+    <Avatar alt={USER_ANONYMOUS.name} {...avatarProps}>
+      {USER_ANONYMOUS.name.substring(0, 1)}
+    </Avatar>
+  );
+};

--- a/src/components/InlineFlex/InlineFlex.tsx
+++ b/src/components/InlineFlex/InlineFlex.tsx
@@ -1,0 +1,21 @@
+import { Flex, FlexProps } from "@mantine/core";
+
+interface InlineFlexProps extends FlexProps {}
+
+/**
+ * Renders a Mantine Flex as an inline-flex span.
+ * @param {InlineFlexProps} props - Props to customize the Flex component.
+ * @returns {JSX.Element} The rendered inline-flex container.
+ */
+export const InlineFlex = ({ children, ...flexProps }: InlineFlexProps) => (
+  <Flex
+    component="span"
+    direction="row"
+    align="center"
+    gap={6}
+    style={{ display: "inline-flex", ...flexProps.style }}
+    {...flexProps}
+  >
+    {children}
+  </Flex>
+);

--- a/src/components/InlineFlex/InlineFlex.tsx
+++ b/src/components/InlineFlex/InlineFlex.tsx
@@ -7,15 +7,19 @@ interface InlineFlexProps extends FlexProps {}
  * @param {InlineFlexProps} props - Props to customize the Flex component.
  * @returns {JSX.Element} The rendered inline-flex container.
  */
-export const InlineFlex = ({ children, ...flexProps }: InlineFlexProps) => (
-  <Flex
-    component="span"
-    direction="row"
-    align="center"
-    gap={6}
-    style={{ display: "inline-flex", ...flexProps.style }}
-    {...flexProps}
-  >
-    {children}
-  </Flex>
-);
+export const InlineFlex = ({ children, ...flexProps }: InlineFlexProps) => {
+  const { style, ...rest } = flexProps;
+
+  return (
+    <Flex
+      component="span"
+      direction="row"
+      align="center"
+      gap={6}
+      style={{ display: "inline-flex", ...style }}
+      {...rest}
+    >
+      {children}
+    </Flex>
+  );
+};

--- a/src/components/StepTimeline/StepTimeline.tsx
+++ b/src/components/StepTimeline/StepTimeline.tsx
@@ -1,0 +1,166 @@
+import { CardProps, rem, Stack, ThemeIcon, Timeline } from "@mantine/core";
+import { IconCactus, IconMessagePlus, IconProps } from "@tabler/icons-react";
+import { useMemo, useState } from "react";
+import { TUseProject, TUseTestCase } from "../../lib/operators/types.ts";
+import { StepTimelineCommentCard } from "./cards/StepTimelineCommentCard.tsx";
+import { StepTimelineEmptyCard } from "./cards/StepTimelineEmptyCard.tsx";
+import { StepTimelineNewCommentCard } from "./cards/StepTimelineNewCommentCard.tsx";
+import { StepTimelineStatusUpdateCard } from "./cards/StepTimelineStatusUpdateCard.tsx";
+import {
+  ActivityType,
+  SortOrder,
+  StepTimelineItem,
+} from "./stepTimeline.types.ts";
+import { ACTIVITIES } from "./stepTimeline.utils.ts";
+import { StepTimelineFilters } from "./StepTimelineFilters/StepTimelineFilters.tsx";
+
+interface StepTimelineProps {
+  list: Array<StepTimelineItem>;
+  testId?: string;
+  stepId?: string;
+  project: TUseProject;
+  createComment: TUseTestCase["createComment"];
+  removeComment: TUseTestCase["removeComment"];
+  updateCommentResolved: TUseTestCase["updateCommentResolved"];
+  updateCommentContent: TUseTestCase["updateCommentContent"];
+}
+
+const commonIconProps: IconProps = { size: rem(18) };
+
+export const StepTimeline = ({
+  list = [],
+  testId,
+  stepId,
+  project,
+  createComment,
+  removeComment,
+  updateCommentResolved,
+  updateCommentContent,
+}: StepTimelineProps) => {
+  const [filteredActivities, setFilteredActivities] = useState<ActivityType[]>(
+    ACTIVITIES.map((a) => a.value),
+  );
+  const [sort, setSort] = useState<SortOrder>("asc");
+
+  // Filter and sort the list based on user selections
+  const filteredList = list
+    .filter((item) => filteredActivities.includes(item.type))
+    .sort((a, b) => {
+      if (sort === "asc") {
+        return a.date - b.date;
+      }
+
+      return b.date - a.date;
+    });
+
+  // Keep common card props in one place for easier adjustments
+  // and to ensure consistency across different card types
+  const commonCardProps: CardProps = {
+    p: "sm",
+  };
+
+  // Determine if comments are visible based on current filters
+  // This helps to decide whether to show the "new comment" card or not
+  // As there is no point in showing it if comments are filtered out.
+  const commentsVisible = useMemo(
+    () =>
+      filteredActivities.includes(ActivityType.Comment) ||
+      filteredActivities.includes(ActivityType.UnsolvedComment),
+    [filteredActivities],
+  );
+
+  const newCommentItem = commentsVisible ? (
+    <Timeline.Item
+      lineVariant="dashed"
+      bullet={<IconMessagePlus size={rem(18)} />}
+    >
+      <StepTimelineNewCommentCard
+        createComment={createComment}
+        testId={testId}
+        stepId={stepId}
+        project={project}
+      />
+    </Timeline.Item>
+  ) : null;
+
+  return (
+    <Stack>
+      <StepTimelineFilters
+        filteredActivities={filteredActivities}
+        setFilteredActivities={setFilteredActivities}
+        setSort={setSort}
+        sort={sort}
+      />
+      <Timeline
+        active={
+          filteredList.length === 0
+            ? -1
+            : filteredList.length - (commentsVisible ? 1 : 0)
+        }
+        reverseActive={sort === "desc"}
+        bulletSize={25}
+        lineWidth={2}
+      >
+        {filteredList.length === 0 ? (
+          <Timeline.Item
+            lineVariant="dashed"
+            bullet={<IconCactus size={rem(18)} />}
+          >
+            <StepTimelineEmptyCard
+              filteredActivities={filteredActivities}
+              setFilteredActivities={setFilteredActivities}
+              {...commonCardProps}
+            />
+          </Timeline.Item>
+        ) : null}
+
+        {/* If sort is desc, the newest comments will be at the top, so we print the new comment card BEFORE the list*/}
+        {sort === "desc" ? newCommentItem : null}
+
+        {filteredList.map((item, index, innerList) => {
+          const isLastItem = index === innerList.length - 1;
+
+          const activity = ACTIVITIES.find((a) => a.value === item.type);
+          const activityLabel = activity?.label ?? "";
+          const ActivityIcon = activity?.icon ?? null;
+          const activityBullet =
+            ActivityIcon !== null ? (
+              <ThemeIcon radius="xl" title={activityLabel}>
+                <ActivityIcon {...commonIconProps} />
+              </ThemeIcon>
+            ) : null;
+
+          const lineVariant = sort === "asc" && isLastItem ? "dashed" : "solid";
+
+          return (
+            <Timeline.Item
+              key={index}
+              lineVariant={lineVariant}
+              bullet={activityBullet}
+            >
+              {item.type === ActivityType.StatusUpdate ? (
+                <StepTimelineStatusUpdateCard
+                  item={item}
+                  {...commonCardProps}
+                />
+              ) : null}
+              {item.type === ActivityType.Comment ||
+              item.type === ActivityType.UnsolvedComment ? (
+                <StepTimelineCommentCard
+                  item={item}
+                  removeComment={removeComment}
+                  updateCommentContent={updateCommentContent}
+                  updateCommentResolved={updateCommentResolved}
+                  {...commonCardProps}
+                />
+              ) : null}
+            </Timeline.Item>
+          );
+        })}
+
+        {/* If sort is asc, the newest comments will be at the bottom, so we print the new comment card AFTER the list*/}
+        {sort === "asc" ? newCommentItem : null}
+      </Timeline>
+    </Stack>
+  );
+};

--- a/src/components/StepTimeline/StepTimeline.tsx
+++ b/src/components/StepTimeline/StepTimeline.tsx
@@ -43,15 +43,19 @@ export const StepTimeline = ({
   const [sort, setSort] = useState<SortOrder>("asc");
 
   // Filter and sort the list based on user selections
-  const filteredList = list
-    .filter((item) => filteredActivities.includes(item.type))
-    .sort((a, b) => {
-      if (sort === "asc") {
-        return a.date - b.date;
-      }
+  const filteredList = useMemo(
+    () =>
+      list
+        .filter((item) => filteredActivities.includes(item.type))
+        .sort((a, b) => {
+          if (sort === "asc") {
+            return a.date - b.date;
+          }
 
-      return b.date - a.date;
-    });
+          return b.date - a.date;
+        }),
+    [filteredActivities, list, sort],
+  );
 
   // Keep common card props in one place for easier adjustments
   // and to ensure consistency across different card types

--- a/src/components/StepTimeline/StepTimelineFilters/StepTimelineFilters.module.css
+++ b/src/components/StepTimeline/StepTimelineFilters/StepTimelineFilters.module.css
@@ -1,0 +1,26 @@
+.checkboxCard {
+    padding: var(--mantine-spacing-xs);
+    transition: border-color 150ms ease;
+    border-color: transparent;
+
+    &[data-checked] {
+        background-color: var(--mantine-color-gray-1);
+    }
+
+    @mixin hover {
+        @mixin light {
+            background-color: var(--mantine-color-gray-0);
+        }
+
+        @mixin dark {
+            background-color: var(--mantine-color-dark-6);
+        }
+    }
+}
+
+.checkboxCardLabel {
+    font-weight: bold;
+    font-size: var(--mantine-font-size-md);
+    line-height: 1.3;
+    color: var(--mantine-color-bright);
+}

--- a/src/components/StepTimeline/StepTimelineFilters/StepTimelineFilters.tsx
+++ b/src/components/StepTimeline/StepTimelineFilters/StepTimelineFilters.tsx
@@ -1,0 +1,142 @@
+import {
+  Button,
+  Checkbox,
+  Combobox,
+  Group,
+  Popover,
+  ScrollArea,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { IconSortAscending, IconSortDescending } from "@tabler/icons-react";
+import { Dispatch, SetStateAction, useCallback } from "react";
+import { ActivityType, SortOrder } from "../stepTimeline.types.ts";
+import { ACTIVITIES } from "../stepTimeline.utils.ts";
+import classes from "./StepTimelineFilters.module.css";
+
+interface StepTimelineFiltersProps {
+  filteredActivities: ActivityType[];
+  setFilteredActivities: Dispatch<SetStateAction<ActivityType[]>>;
+  setSort: Dispatch<SetStateAction<SortOrder>>;
+  sort: SortOrder;
+}
+
+export const StepTimelineFilters = ({
+  filteredActivities,
+  setFilteredActivities,
+  setSort,
+  sort,
+}: StepTimelineFiltersProps) => {
+  const [activitiesListOpened, activitiesListHandlers] = useDisclosure(false);
+
+  const sortHandler = useCallback(() => {
+    if (setSort !== undefined) {
+      setSort((current) => (current === "asc" ? "desc" : "asc"));
+    }
+  }, [setSort]);
+
+  const toggleSelectAllHandler = useCallback(() => {
+    if (filteredActivities.length === ACTIVITIES.length) {
+      setFilteredActivities([]);
+    } else {
+      setFilteredActivities(ACTIVITIES.map((a) => a.value));
+    }
+  }, [filteredActivities.length, setFilteredActivities]);
+
+  const filteredActivitiesChangeHandler = useCallback(
+    (values: string[]) => {
+      if (setFilteredActivities) {
+        setFilteredActivities(values as ActivityType[]);
+      }
+    },
+    [setFilteredActivities],
+  );
+
+  return (
+    <Group align="center" justify="flex-end">
+      <Button.Group>
+        <Popover
+          opened={activitiesListOpened}
+          onChange={activitiesListHandlers.toggle}
+          trapFocus
+          withArrow
+          width={300}
+          position="bottom-end"
+          arrowOffset={20}
+          arrowSize={10}
+          shadow="md"
+        >
+          <Popover.Target>
+            <Button
+              variant="default"
+              onClick={activitiesListHandlers.toggle}
+              rightSection={<Combobox.Chevron />}
+            >
+              {filteredActivities.length === ACTIVITIES.length
+                ? "All activity"
+                : filteredActivities.length === 0
+                  ? "No activity"
+                  : `${filteredActivities.length} activity`}
+            </Button>
+          </Popover.Target>
+
+          <Popover.Dropdown>
+            <Stack gap="sm">
+              <Group justify="space-between" align="center" wrap="nowrap">
+                <Text span inline size="md" fw="bold">
+                  Filter Activity
+                </Text>
+                <Button
+                  variant="subtle"
+                  color="primary"
+                  size="compact-md"
+                  component="a"
+                  onClick={toggleSelectAllHandler}
+                >
+                  {filteredActivities.length === ACTIVITIES.length
+                    ? "Deselect All"
+                    : "Select All"}
+                </Button>
+              </Group>
+              <ScrollArea.Autosize mah={250} offsetScrollbars>
+                <Checkbox.Group
+                  value={filteredActivities}
+                  onChange={filteredActivitiesChangeHandler}
+                >
+                  <Stack gap={6}>
+                    {ACTIVITIES.map((activity) => (
+                      <Checkbox.Card
+                        radius="md"
+                        value={activity.value}
+                        key={activity.value}
+                        className={classes.checkboxCard}
+                      >
+                        <Group wrap="nowrap" align="flex-start">
+                          <Checkbox.Indicator />
+                          <div className={classes.checkboxCardLabel}>
+                            <Text inline span>
+                              {activity.label}
+                            </Text>
+                          </div>
+                        </Group>
+                      </Checkbox.Card>
+                    ))}
+                  </Stack>
+                </Checkbox.Group>
+              </ScrollArea.Autosize>
+            </Stack>
+          </Popover.Dropdown>
+        </Popover>
+
+        <Button variant="default" onClick={sortHandler}>
+          {sort === "asc" ? (
+            <IconSortAscending size={20} />
+          ) : (
+            <IconSortDescending size={20} />
+          )}
+        </Button>
+      </Button.Group>
+    </Group>
+  );
+};

--- a/src/components/StepTimeline/StepTimelineFilters/StepTimelineFilters.tsx
+++ b/src/components/StepTimeline/StepTimelineFilters/StepTimelineFilters.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconSortAscending, IconSortDescending } from "@tabler/icons-react";
-import { Dispatch, SetStateAction, useCallback } from "react";
+import { Dispatch, SetStateAction, useCallback, useMemo } from "react";
 import { ActivityType, SortOrder } from "../stepTimeline.types.ts";
 import { ACTIVITIES } from "../stepTimeline.utils.ts";
 import classes from "./StepTimelineFilters.module.css";
@@ -53,6 +53,20 @@ export const StepTimelineFilters = ({
     [setFilteredActivities],
   );
 
+  const activitiesLabel = useMemo(() => {
+    const allActivitiesSelected =
+      filteredActivities.length === ACTIVITIES.length;
+    const noActivitiesSelected = filteredActivities.length === 0;
+
+    if (allActivitiesSelected) {
+      return "All activity";
+    }
+    if (noActivitiesSelected) {
+      return "No activity";
+    }
+    return `${filteredActivities.length} activity`;
+  }, [filteredActivities.length]);
+
   return (
     <Group align="center" justify="flex-end">
       <Button.Group>
@@ -73,11 +87,7 @@ export const StepTimelineFilters = ({
               onClick={activitiesListHandlers.toggle}
               rightSection={<Combobox.Chevron />}
             >
-              {filteredActivities.length === ACTIVITIES.length
-                ? "All activity"
-                : filteredActivities.length === 0
-                  ? "No activity"
-                  : `${filteredActivities.length} activity`}
+              {activitiesLabel}
             </Button>
           </Popover.Target>
 

--- a/src/components/StepTimeline/cards/StepTimelineCommentCard.module.css
+++ b/src/components/StepTimeline/cards/StepTimelineCommentCard.module.css
@@ -1,0 +1,11 @@
+.comment {
+    .fadedElement {
+        transition: opacity 0.2s ease-in-out;
+    }
+
+    &.commentSolved {
+        .fadedElement {
+            opacity: 0.5;
+        }
+    }
+}

--- a/src/components/StepTimeline/cards/StepTimelineCommentCard.tsx
+++ b/src/components/StepTimeline/cards/StepTimelineCommentCard.tsx
@@ -1,0 +1,173 @@
+import {
+  Button,
+  Card,
+  CardProps,
+  Group,
+  Image,
+  Indicator,
+  Stack,
+  Text,
+  ThemeIcon,
+  Tooltip,
+} from "@mantine/core";
+import clsx from "clsx";
+import { useCallback } from "react";
+import { useParams } from "react-router-dom";
+import CheckCircle from "../../../assets/icons/check_circle.svg";
+import CheckCircleFull from "../../../assets/icons/check_circle_full.svg";
+import Delete from "../../../assets/icons/delete.svg";
+import { USER_ANONYMOUS } from "../../../lib/constants/generic.ts";
+import { getStatusColor } from "../../../lib/helpers/getStatusColor.ts";
+import { getStatusIcon } from "../../../lib/helpers/getStatusIcon.ts";
+import { getStatusLabel } from "../../../lib/helpers/getStatusLabel.ts";
+import { TUseTestCase } from "../../../lib/operators/types.ts";
+import { useProject } from "../../../lib/operators/useProject.ts";
+import { StatusEnum } from "../../../types/schema.ts";
+import { CollaboratorAvatar } from "../../CollaboratorAvatar/CollaboratorAvatar.tsx";
+import { CommentBreadcrumbs } from "../../commentsList/CommentBreadcrumbs.tsx";
+
+import { openDeleteConfirmModal } from "../../modals/modals.ts";
+import { EditableHtmlText } from "../../shared/EditableHtmlText.tsx";
+import { RelativeDate } from "../../shared/relativeDate/RelativeDate.tsx";
+import { StepTimelineComment } from "../stepTimeline.types.ts";
+import classes from "./StepTimelineCommentCard.module.css";
+
+interface StepTimelineCommentCardProps extends CardProps {
+  item: StepTimelineComment;
+  removeComment: TUseTestCase["removeComment"];
+  updateCommentContent: TUseTestCase["updateCommentContent"];
+  updateCommentResolved: TUseTestCase["updateCommentResolved"];
+}
+
+export const StepTimelineCommentCard = ({
+  className,
+  item,
+  removeComment,
+  updateCommentContent,
+  updateCommentResolved,
+  ...cardProps
+}: StepTimelineCommentCardProps) => {
+  const params = useParams();
+  const project = useProject(params.projectId);
+
+  const collaborator = item?.comment?.collaboratorId
+    ? project.getCollaborator(item?.comment?.collaboratorId)
+    : undefined;
+
+  const toggleIsResolved = useCallback(() => {
+    updateCommentResolved(!item?.comment?.resolved, item?.comment.id);
+  }, [item?.comment.id, item?.comment?.resolved, updateCommentResolved]);
+
+  const updateContent = useCallback(
+    (content: string) => {
+      updateCommentContent(content, item?.comment.id);
+    },
+    [item?.comment.id, updateCommentContent],
+  );
+
+  const updateContentHandler = useCallback(
+    (content: string) => updateContent(content),
+    [updateContent],
+  );
+
+  const deleteCommentHandler = useCallback(() => {
+    openDeleteConfirmModal("Are you sure you want to delete this comment?", {
+      handleConfirm: () => removeComment(item?.comment.id),
+    });
+  }, [item?.comment.id, removeComment]);
+
+  const StatusIcon = getStatusIcon(
+    item?.comment?.testStatusWhenCreated ?? StatusEnum.TODO,
+  );
+
+  return (
+    <Card
+      radius="md"
+      className={clsx(classes.comment, className, {
+        [classes.commentSolved]: item?.comment?.resolved,
+      })}
+      {...cardProps}
+    >
+      <Stack>
+        {/* Heading with Avatar, collaborator name and Mark/Delete buttons*/}
+        <Group align="center" justify="space-between">
+          <Group>
+            <Indicator
+              offset={3}
+              position="bottom-end"
+              color="white"
+              label={
+                <Tooltip
+                  label={`Status when added: ${getStatusLabel(item?.comment?.testStatusWhenCreated)}`}
+                  withArrow
+                  events={{ hover: true, focus: false, touch: true }}
+                >
+                  <ThemeIcon
+                    color={getStatusColor(item?.comment?.testStatusWhenCreated)}
+                    variant="white"
+                    radius="xl"
+                  >
+                    <StatusIcon size="1.6rem" />
+                  </ThemeIcon>
+                </Tooltip>
+              }
+              styles={{
+                indicator: { padding: 0 },
+              }}
+            >
+              <CollaboratorAvatar collaborator={collaborator} />
+            </Indicator>
+            <Stack gap={4}>
+              <Text span inline fw="bold">
+                {collaborator?.name ?? USER_ANONYMOUS.name}
+              </Text>
+              <Text span inline c="dimmed" size="sm">
+                <RelativeDate timeStamp={item?.comment?.createdAt} />
+              </Text>
+            </Stack>
+          </Group>
+          <Group gap={6} wrap="nowrap">
+            <Button variant="transparent" p={0} onClick={toggleIsResolved}>
+              <Tooltip
+                label={
+                  item?.comment?.resolved
+                    ? "Unmark as Resolved"
+                    : "Mark as Resolved"
+                }
+              >
+                <Image
+                  alt={item?.comment?.resolved ? "Resolved" : "To resolve"}
+                  src={item?.comment?.resolved ? CheckCircleFull : CheckCircle}
+                  h={24}
+                  w={24}
+                />
+              </Tooltip>
+            </Button>
+            <Button variant="transparent" p={0} onClick={deleteCommentHandler}>
+              <Tooltip label="Delete comment">
+                <Image alt="Delete" src={Delete} h={24} w={24} />
+              </Tooltip>
+            </Button>
+          </Group>
+        </Group>
+
+        {/* Comment breadcrumbs and content */}
+        <Stack gap={6}>
+          <CommentBreadcrumbs
+            className={classes.fadedElement}
+            projectId={project.data?.id ?? ""}
+            comment={item.comment}
+          />
+          <EditableHtmlText
+            name="comment"
+            textProps={{
+              className: classes.fadedElement,
+            }}
+            value={item?.comment?.content}
+            onChange={updateContentHandler}
+          />
+        </Stack>
+      </Stack>
+    </Card>
+  );
+};

--- a/src/components/StepTimeline/cards/StepTimelineEmptyCard.tsx
+++ b/src/components/StepTimeline/cards/StepTimelineEmptyCard.tsx
@@ -1,0 +1,49 @@
+import { Anchor, Card, CardProps, Stack, Text } from "@mantine/core";
+import { IconCactus } from "@tabler/icons-react";
+import { Dispatch, SetStateAction } from "react";
+import { ActivityType } from "../stepTimeline.types.ts";
+import { ACTIVITIES } from "../stepTimeline.utils.ts";
+
+interface StepTimelineEmptyCardProps extends CardProps {
+  filteredActivities: ActivityType[];
+  setFilteredActivities: Dispatch<SetStateAction<ActivityType[]>>;
+}
+
+export const StepTimelineEmptyCard = ({
+  filteredActivities,
+  setFilteredActivities,
+  ...cardProps
+}: StepTimelineEmptyCardProps) => (
+  <Card radius="md" {...cardProps}>
+    <Stack justify="center" align="center" py="md">
+      <Text inline span c="dimmed">
+        <IconCactus size={40} color="currentColor" />
+      </Text>
+      <Stack gap="md" justify="center" align="center">
+        <Text inline span fw="bold" ta="center">
+          Nothing here!
+        </Text>
+        <Stack gap={4}>
+          <Text inline span ta="center">
+            There are no activities to show!
+          </Text>
+          {filteredActivities.length === 0 ? (
+            <Text inline span ta="center">
+              {" "}
+              Try to{" "}
+              <Anchor
+                onClick={() =>
+                  setFilteredActivities(ACTIVITIES.map((a) => a.value))
+                }
+                style={{ cursor: "pointer" }}
+              >
+                reset the filters
+              </Anchor>{" "}
+              to get started.
+            </Text>
+          ) : null}
+        </Stack>
+      </Stack>
+    </Stack>
+  </Card>
+);

--- a/src/components/StepTimeline/cards/StepTimelineNewCommentCard.tsx
+++ b/src/components/StepTimeline/cards/StepTimelineNewCommentCard.tsx
@@ -1,0 +1,32 @@
+import { Card, CardProps, Stack, Text } from "@mantine/core";
+import { TUseProject, TUseTestCase } from "../../../lib/operators/types.ts";
+import { NewCommentForm } from "../../commentsList/NewCommentForm.tsx";
+
+interface StepTimelineNewCommentCardProps extends CardProps {
+  testId?: string;
+  stepId?: string;
+  project: TUseProject;
+  createComment: TUseTestCase["createComment"];
+}
+
+export const StepTimelineNewCommentCard = ({
+  testId,
+  stepId,
+  project,
+  createComment,
+  ...cardProps
+}: StepTimelineNewCommentCardProps) => {
+  return (
+    <Card {...cardProps}>
+      <Stack gap="sm">
+        <Text size="lg">Add a new Comment</Text>
+        <NewCommentForm
+          createComment={createComment}
+          project={project}
+          stepId={stepId}
+          testId={testId}
+        />
+      </Stack>
+    </Card>
+  );
+};

--- a/src/components/StepTimeline/cards/StepTimelineStatusUpdateCard.tsx
+++ b/src/components/StepTimeline/cards/StepTimelineStatusUpdateCard.tsx
@@ -1,0 +1,72 @@
+import { Card, CardProps, Group, Stack, Text } from "@mantine/core";
+import { useParams } from "react-router-dom";
+import { getStatusLabel } from "../../../lib/helpers/getStatusLabel.ts";
+import { useProject } from "../../../lib/operators/useProject.ts";
+import { CollaboratorAnchor } from "../../CollaboratorAnchor/CollaboratorAnchor.tsx";
+import { InlineFlex } from "../../InlineFlex/InlineFlex.tsx";
+import { RelativeDate } from "../../shared/relativeDate/RelativeDate.tsx";
+import { StatusIcon } from "../../statusIcon/StatusIcon.tsx";
+import { StepTimelineStatusUpdate } from "../stepTimeline.types.ts";
+
+interface StepTimelineStatusUpdateProps extends CardProps {
+  item: StepTimelineStatusUpdate;
+}
+
+export const StepTimelineStatusUpdateCard = ({
+  item,
+  ...cardProps
+}: StepTimelineStatusUpdateProps) => {
+  const params = useParams();
+  const project = useProject(params.projectId);
+
+  const collaborator = item?.statusUpdate.collaboratorId
+    ? project.getCollaborator(item?.statusUpdate?.collaboratorId)
+    : undefined;
+
+  const updateDate = (
+    <Text span inline c="dimmed" size="sm">
+      <RelativeDate timeStamp={item.statusUpdate?.createdAt} />
+    </Text>
+  );
+
+  return (
+    <Card radius="md" {...cardProps}>
+      <Stack>
+        <Group gap="md" align="center" justify="space-between">
+          <Text span inline c="gray.7">
+            <InlineFlex wrap="wrap">
+              <CollaboratorAnchor collaborator={collaborator} withHoverCard />{" "}
+              updated the status from{" "}
+              <InlineFlex>
+                <StatusIcon
+                  status={item?.statusUpdate?.previousStatus}
+                  showTooltip={false}
+                />
+                <Text inline span>
+                  {getStatusLabel(item?.statusUpdate?.previousStatus)}
+                </Text>
+              </InlineFlex>{" "}
+              to{" "}
+              <InlineFlex>
+                <StatusIcon
+                  status={item?.statusUpdate?.targetStatus}
+                  showTooltip={false}
+                />
+                <Text inline span>
+                  {getStatusLabel(item?.statusUpdate?.targetStatus)}
+                </Text>
+              </InlineFlex>
+            </InlineFlex>
+          </Text>
+          {updateDate}
+        </Group>
+        {item?.statusUpdate?.notes !== undefined &&
+        item.statusUpdate.notes !== "" ? (
+          <Text span inline>
+            {item.statusUpdate.notes}
+          </Text>
+        ) : null}
+      </Stack>
+    </Card>
+  );
+};

--- a/src/components/StepTimeline/stepTimeline.types.ts
+++ b/src/components/StepTimeline/stepTimeline.types.ts
@@ -1,0 +1,34 @@
+import { TablerIcon } from "@tabler/icons-react";
+import { ReactNode } from "react";
+import { TComment, TStatusChange } from "../../types/schema.ts";
+
+export enum ActivityType {
+  Comment = "comments",
+  StatusUpdate = "statusUpdates",
+  UnsolvedComment = "comment",
+}
+
+export interface Activity {
+  label: string;
+  value: ActivityType;
+  icon: TablerIcon;
+}
+
+export type SortOrder = "asc" | "desc";
+
+export type StepTimelineItem = StepTimelineComment | StepTimelineStatusUpdate;
+
+type StepTimelineBase = {
+  icon?: ReactNode;
+  date: number;
+};
+
+export type StepTimelineComment = StepTimelineBase & {
+  type: ActivityType.Comment | ActivityType.UnsolvedComment;
+  comment: TComment;
+};
+
+export type StepTimelineStatusUpdate = StepTimelineBase & {
+  type: ActivityType.StatusUpdate;
+  statusUpdate: TStatusChange;
+};

--- a/src/components/StepTimeline/stepTimeline.utils.ts
+++ b/src/components/StepTimeline/stepTimeline.utils.ts
@@ -1,0 +1,24 @@
+import {
+  IconMessage,
+  IconMessageOff,
+  IconProgressCheck,
+} from "@tabler/icons-react";
+import { Activity, ActivityType } from "./stepTimeline.types.ts";
+
+export const ACTIVITIES: Activity[] = [
+  {
+    label: "Comment (unsolved)",
+    value: ActivityType.UnsolvedComment,
+    icon: IconMessage,
+  },
+  {
+    label: "Comment (resolved)",
+    value: ActivityType.Comment,
+    icon: IconMessageOff,
+  },
+  {
+    label: "Status Update",
+    value: ActivityType.StatusUpdate,
+    icon: IconProgressCheck,
+  },
+];

--- a/src/components/commentsList/CommentBreadcrumbs.tsx
+++ b/src/components/commentsList/CommentBreadcrumbs.tsx
@@ -1,21 +1,22 @@
-import { Anchor, Text } from "@mantine/core";
+import { Anchor, Text, TextProps } from "@mantine/core";
+import { Link } from "react-router-dom";
+import { routesHelper } from "../../lib/helpers/routesHelper";
+import { useServerName } from "../../lib/helpers/useServerName";
 import { useStep } from "../../lib/operators/useStep";
 import { useTest } from "../../lib/operators/useTest";
 import { useTestCase } from "../../lib/operators/useTestCase";
-import { routesHelper } from "../../lib/helpers/routesHelper";
 import { TComment } from "../../types/schema";
-import { Link } from "react-router-dom";
-import { useServerName } from "../../lib/helpers/useServerName";
-import classes from "./CommentsList.module.css";
 
-type CommentBreadcrumbsProps = {
+interface CommentBreadcrumbsProps extends TextProps {
   readonly projectId: string;
   readonly comment: TComment;
-};
+}
 
 export function CommentBreadcrumbs({
   projectId,
   comment,
+  className,
+  ...textProps
 }: CommentBreadcrumbsProps) {
   const serverName = useServerName();
   const testCase = useTestCase(projectId, comment.caseId);
@@ -30,7 +31,7 @@ export function CommentBreadcrumbs({
   const separator = " > ";
 
   return (
-    <Text size="sm" className={classes.fadedElement}>
+    <Text size="sm" className={className} {...textProps}>
       {testCase.data ? (
         <Anchor
           component={Link}

--- a/src/components/commentsList/CommentsList.tsx
+++ b/src/components/commentsList/CommentsList.tsx
@@ -284,6 +284,7 @@ export function CommentsList({
                     </Text>
 
                     <CommentBreadcrumbs
+                      className={classes.fadedElement}
                       projectId={project.data?.id}
                       comment={comment}
                     />

--- a/src/components/commentsList/CommentsList.tsx
+++ b/src/components/commentsList/CommentsList.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Box,
   Button,
   Flex,
@@ -12,8 +11,8 @@ import {
   Title,
   Tooltip,
 } from "@mantine/core";
-
 import { useForm } from "@mantine/form";
+import clsx from "clsx";
 import { useCallback, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import CheckCircle from "../../assets/icons/check_circle.svg";
@@ -22,17 +21,16 @@ import Delete from "../../assets/icons/delete.svg";
 import { USER_ANONYMOUS } from "../../lib/constants/generic.ts";
 import { TUseTestCase } from "../../lib/operators/types";
 import { useProject } from "../../lib/operators/useProject";
-import { TCollaborator, TComment, TStep, TTest } from "../../types/schema";
-import { Avatars } from "../avatars/Avatars";
+import { TComment, TStep, TTest } from "../../types/schema";
+import { CollaboratorAvatar } from "../CollaboratorAvatar/CollaboratorAvatar.tsx";
 import { openDeleteConfirmModal } from "../modals/modals";
+import { EditableHtmlText } from "../shared/EditableHtmlText.tsx";
 import { RelativeDate } from "../shared/relativeDate/RelativeDate.tsx";
 import { StatusIconWithLabel } from "../statusIcon/StatusIconWithLabel.tsx";
 import { CommentBreadcrumbs } from "./CommentBreadcrumbs";
+import classes from "./CommentsList.module.css";
 import { NewCommentForm } from "./NewCommentForm.tsx";
 import { TFilterForm } from "./types";
-import classes from "./CommentsList.module.css";
-import clsx from "clsx";
-import { EditableHtmlText } from "../shared/EditableHtmlText.tsx";
 
 type CommentsListProps = Readonly<{
   testId?: string;
@@ -146,18 +144,6 @@ export function CommentsList({
     return null;
   }
 
-  const collaboratorAvatar = (collaborator?: TCollaborator) => {
-    if (collaborator) {
-      return <Avatars collaborators={[collaborator]} maxAvatars={1} />;
-    }
-
-    return (
-      <Avatar alt={USER_ANONYMOUS.name}>
-        {USER_ANONYMOUS.name.substring(0, 1)}
-      </Avatar>
-    );
-  };
-
   return (
     <>
       {showTitle ? <Title order={4}>Notes</Title> : null}
@@ -220,7 +206,7 @@ export function CommentsList({
                     [classes.commentSolved]: comment.resolved,
                   })}
                 >
-                  {collaboratorAvatar(collaborator)}
+                  <CollaboratorAvatar collaborator={collaborator} />
                   <Flex
                     direction={"column"}
                     gap={12}

--- a/src/components/statusIcon/StatusIcon.tsx
+++ b/src/components/statusIcon/StatusIcon.tsx
@@ -5,16 +5,8 @@ import {
   Tooltip,
 } from "@mantine/core";
 import { CSSProperties, useMemo } from "react";
-import {
-  MdCheckCircle,
-  MdDangerous,
-  MdDeleteForever,
-  MdNotStarted,
-  MdPauseCircle,
-  MdPending,
-  MdReportProblem,
-} from "react-icons/md";
 import { getStatusColor } from "../../lib/helpers/getStatusColor";
+import { getStatusIcon } from "../../lib/helpers/getStatusIcon.ts";
 import { getStatusLabel } from "../../lib/helpers/getStatusLabel";
 import { StatusEnum } from "../../types/schema";
 import classes from "./statusIcon.module.css";
@@ -53,29 +45,8 @@ export const StatusIcon = ({
   }, [hoverColor, style]);
 
   const statusIcon = useMemo(() => {
-    switch (status) {
-      case StatusEnum.BLOCKED:
-        return <MdDeleteForever size="1.5rem" />;
-
-      case StatusEnum.CANCELLED:
-        return <MdDangerous size="1.5rem" />;
-
-      case StatusEnum.DONE:
-        return <MdCheckCircle size="1.5rem" />;
-
-      case StatusEnum.FAIL:
-        return <MdReportProblem size="1.5rem" />;
-
-      case StatusEnum.PAUSED:
-        return <MdPauseCircle size="1.5rem" />;
-
-      default:
-      case StatusEnum.PENDING:
-        return <MdPending size="1.5rem" />;
-
-      case StatusEnum.TODO:
-        return <MdNotStarted size="1.5rem" />;
-    }
+    const Icon = getStatusIcon(status);
+    return <Icon size="1.5rem" />;
   }, [status]);
 
   const themeIcon = (

--- a/src/components/statusIcon/StatusIcon.tsx
+++ b/src/components/statusIcon/StatusIcon.tsx
@@ -34,15 +34,11 @@ export const StatusIcon = ({
   const tooltip = getStatusLabel(status);
 
   const styles = useMemo(() => {
-    if (hoverColor) {
-      return {
-        "--status-icon-hover-color": hoverColor, // passing the hoverColor through CSS variable since Mantine doesn't support '&:hover' in styles since 7.x
-        ...style,
-      };
-    }
-
-    return style;
-  }, [hoverColor, style]);
+    return {
+      "--status-icon-hover-color": hoverColor ?? statusColor, // passing the hoverColor through CSS variable since Mantine doesn't support '&:hover' in styles since 7.x
+      ...style,
+    };
+  }, [hoverColor, statusColor, style]);
 
   const statusIcon = useMemo(() => {
     const Icon = getStatusIcon(status);

--- a/src/components/stepDetails/stepDetails.tsx
+++ b/src/components/stepDetails/stepDetails.tsx
@@ -1,5 +1,6 @@
-import { Button, Group, Image, Tabs, Text, Title } from "@mantine/core";
+import { Box, Button, Group, Image, Text } from "@mantine/core";
 import { modals } from "@mantine/modals";
+import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import CircleX from "../../assets/icons/circle_x.svg";
 import { getStatusLabel } from "../../lib/helpers/getStatusLabel.ts";
@@ -10,8 +11,8 @@ import { useStep } from "../../lib/operators/useStep";
 import { useTest } from "../../lib/operators/useTest";
 import { useTestCase } from "../../lib/operators/useTestCase";
 import { StatusEnum } from "../../types/schema";
-import { CommentsList } from "../commentsList/CommentsList";
 import { ContentHeader } from "../contentHeader/ContentHeader";
+import { ContentWrapper } from "../layout/ContentWrapper/ContentWrapper.tsx";
 import { ChangeStatusFormValues } from "../modals/changeStatusModal/ChangeStatusModal.tsx";
 import { Modals } from "../modals/modals.ts";
 import { EditableHtmlText } from "../shared/EditableHtmlText";
@@ -19,10 +20,15 @@ import { SectionError } from "../shared/SectionError";
 import { SectionLoading } from "../shared/SectionLoading";
 import { StatusIcon } from "../statusIcon/StatusIcon.tsx";
 import { StepSwitch } from "../stepSwitch/StepSwitch";
+import { StepTimeline } from "../StepTimeline/StepTimeline.tsx";
+import {
+  ActivityType,
+  StepTimelineComment,
+  StepTimelineItem,
+  StepTimelineStatusUpdate,
+} from "../StepTimeline/stepTimeline.types.ts";
 import { ClosestStepsButtons } from "./ClosestStepsButtons";
 import classes from "./stepDetails.module.css";
-import { StepLog } from "./StepLog";
-import { ContentWrapper } from "../layout/ContentWrapper/ContentWrapper.tsx";
 
 export const StepDetails = () => {
   const navigate = useNavigate();
@@ -37,6 +43,36 @@ export const StepDetails = () => {
     params.testId,
     params.stepId,
   );
+
+  const comments: StepTimelineComment[] = useMemo(
+    () =>
+      testCase?.data?.comments
+        .filter((comment) => comment.stepId === step?.data?.id)
+        .map((comment) => ({
+          comment,
+          type: comment.resolved
+            ? ActivityType.Comment
+            : ActivityType.UnsolvedComment,
+          date: comment.createdAt,
+        })) ?? [],
+    [step?.data?.id, testCase?.data?.comments],
+  );
+
+  const statusChanges: StepTimelineStatusUpdate[] = useMemo(
+    () =>
+      project
+        .getStatusChangesByStepId(step?.data?.id ?? "")
+        .map((statusUpdate) => ({
+          statusUpdate,
+          type: ActivityType.StatusUpdate,
+          date: statusUpdate.createdAt,
+        })) ?? [],
+    [project, step?.data?.id],
+  );
+
+  const list: StepTimelineItem[] = useMemo(() => {
+    return [...(comments ?? []), ...(statusChanges ?? [])];
+  }, [comments, statusChanges]);
 
   if (step.loading || project.loading || testCase.loading || test.loading) {
     return <SectionLoading />;
@@ -106,8 +142,8 @@ export const StepDetails = () => {
 
   return (
     <ContentWrapper>
-      <div className={classes.stepDetails}>
-        <div className={classes.backButton}>
+      <Box className={classes.stepDetails}>
+        <Box className={classes.backButton}>
           <Button
             variant="transparent"
             leftSection={<Image alt="Close" src={CircleX} />}
@@ -116,14 +152,14 @@ export const StepDetails = () => {
           >
             <Text c={"black"}>Close</Text>
           </Button>
-        </div>
+        </Box>
         <ContentHeader
           status={step.data.status}
           title={step.data.title}
           handleDeleteClick={handleDeleteClick}
           handleQuickEdit={handleQuickEdit}
         />
-        <div className={classes.description}>
+        <Box className={classes.description}>
           <EditableHtmlText
             name="description"
             onChange={(value) => {
@@ -137,16 +173,16 @@ export const StepDetails = () => {
             }}
             value={step.data.description}
           />
-        </div>
+        </Box>
 
-        <div className={classes.stepSwitch}>
+        <Box className={classes.stepSwitch}>
           <StepSwitch
             currentStatus={step.data.status}
             onChange={onStatusChange}
           />
-        </div>
+        </Box>
 
-        <div className={classes.closestSteps}>
+        <Box className={classes.closestSteps}>
           <ClosestStepsButtons
             caseId={testCase.data?.id}
             projectId={project.data.id}
@@ -154,41 +190,23 @@ export const StepDetails = () => {
             steps={test.data?.steps}
             testId={test.data?.id}
           />
-        </div>
+        </Box>
 
-        <div className={classes.comments}>
-          {testCase.data && test.data && (
-            <Tabs defaultValue="notes">
-              <Tabs.List mb="md">
-                <Tabs.Tab value="notes" className={classes.tab}>
-                  <Title order={4}>Notes</Title>
-                </Tabs.Tab>
-                <Tabs.Tab value="log" className={classes.tab}>
-                  <Title order={4}>Log</Title>
-                </Tabs.Tab>
-              </Tabs.List>
-
-              <Tabs.Panel value="notes" pt="xs">
-                <CommentsList
-                  testId={test.data.id}
-                  stepId={step.data.id}
-                  comments={testCase.data.comments.filter(
-                    (comment) => comment.stepId === step.data.id,
-                  )}
-                  createComment={testCase.createComment}
-                  removeComment={testCase.removeComment}
-                  updateCommentResolved={testCase.updateCommentResolved}
-                  updateCommentContent={testCase.updateCommentContent}
-                  showTitle={false}
-                />
-              </Tabs.Panel>
-              <Tabs.Panel value="log" pt="xs">
-                <StepLog project={project} stepId={step.data.id} />
-              </Tabs.Panel>
-            </Tabs>
-          )}
-        </div>
-      </div>
+        {testCase.data && test.data ? (
+          <Box className={classes.comments}>
+            <StepTimeline
+              list={list}
+              project={project}
+              testId={test.data.id}
+              stepId={step.data.id}
+              createComment={testCase.createComment}
+              removeComment={testCase.removeComment}
+              updateCommentResolved={testCase.updateCommentResolved}
+              updateCommentContent={testCase.updateCommentContent}
+            />
+          </Box>
+        ) : null}
+      </Box>
     </ContentWrapper>
   );
 };

--- a/src/lib/helpers/getStatusIcon.ts
+++ b/src/lib/helpers/getStatusIcon.ts
@@ -20,7 +20,7 @@ import { StatusEnum } from "../../types/schema.ts";
  * @param {StatusEnum} status - The status to get the icon for.
  * @returns {IconType} The icon component associated with the status.
  */
-export const getStatusIcon = (status: StatusEnum): IconType => {
+export const getStatusIcon = (status?: StatusEnum): IconType => {
   switch (status) {
     case StatusEnum.BLOCKED:
       return MdDeleteForever;
@@ -34,6 +34,7 @@ export const getStatusIcon = (status: StatusEnum): IconType => {
       return MdPauseCircle;
     case StatusEnum.PENDING:
       return MdPending;
+    default:
     case StatusEnum.TODO:
       return MdNotStarted;
   }

--- a/src/lib/helpers/getStatusIcon.ts
+++ b/src/lib/helpers/getStatusIcon.ts
@@ -1,0 +1,40 @@
+import { IconType } from "react-icons";
+import {
+  MdCheckCircle,
+  MdDangerous,
+  MdDeleteForever,
+  MdNotStarted,
+  MdPauseCircle,
+  MdPending,
+  MdReportProblem,
+} from "react-icons/md";
+import { StatusEnum } from "../../types/schema.ts";
+
+/**
+ * Returns the corresponding icon component for a given status.
+ *
+ * Example:
+ * `const Icon  = getStatusIcon(status);`.
+ * Then use `<Icon />` where needed
+ *
+ * @param {StatusEnum} status - The status to get the icon for.
+ * @returns {IconType} The icon component associated with the status.
+ */
+export const getStatusIcon = (status: StatusEnum): IconType => {
+  switch (status) {
+    case StatusEnum.BLOCKED:
+      return MdDeleteForever;
+    case StatusEnum.CANCELLED:
+      return MdDangerous;
+    case StatusEnum.DONE:
+      return MdCheckCircle;
+    case StatusEnum.FAIL:
+      return MdReportProblem;
+    case StatusEnum.PAUSED:
+      return MdPauseCircle;
+    case StatusEnum.PENDING:
+      return MdPending;
+    case StatusEnum.TODO:
+      return MdNotStarted;
+  }
+};


### PR DESCRIPTION
Replace `StepLog` and `CommentsList` with a new `StepTimeline` Component

Features:
- sortable
- filterable by activities (`Comment`, `Comment (resolved)`, `Status Update` for now, can be easily extended)
- new comment form will show ONLY if comments are visible
- new comment form will be shown above if sorting is `desc` (newest first) OR below if sorting is `asc` (oldest first)

<img width="1063" height="976" alt="image" src="https://github.com/user-attachments/assets/af244a06-8398-4158-8d84-24c2f796a79b" />

<img width="1056" height="1345" alt="image" src="https://github.com/user-attachments/assets/3571e50c-6540-4420-b4ba-b3e69efd5fa6" />

<img width="1065" height="1119" alt="image" src="https://github.com/user-attachments/assets/80c09f59-5c45-4f9e-b2df-c03f770151bc" />

Tooltip detail when hovering the avatar (with status Badge) in the comment card
<img width="224" height="86" alt="image" src="https://github.com/user-attachments/assets/65ad21e9-feef-4035-93b3-205d84a49fea" />


Empty list when all activities are filtered out:
<img width="775" height="477" alt="image" src="https://github.com/user-attachments/assets/e635296c-12c3-42c4-b56c-9de6b2fbb1a9" />

Empty list when there are no activities to show (all activities enabled):
<img width="778" height="718" alt="image" src="https://github.com/user-attachments/assets/bc4ed66c-c3d8-45e8-ba5f-3f413267bb8f" />

Resolve #141 

