### PR TITLE
Feature/184 enable update status dialog

### DIFF
--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -45,7 +45,7 @@ export function Settings() {
   const [tags, setTags] = useState<string[]>([]);
   const [collaborators, setCollaborators] = useState<TCollaborator[]>([]);
 
-  const settings = useMemo(() => project.getSettings(), [project]);
+  const projectSettings = useMemo(() => project.getSettings(), [project]);
 
   useEffect(() => {
     if (project.data?.allTags) {
@@ -129,7 +129,7 @@ export function Settings() {
           <Stack>
             <Switch
               checked={
-                settings?.enableUpdateStatusDialog ??
+                projectSettings?.enableUpdateStatusDialog ??
                 DEFAULT_PROJECT_SETTINGS.enableUpdateStatusDialog
               }
               label="Enable Update Status dialog"

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import {
   IconDeviceFloppy,
   IconFileExport,
@@ -13,10 +13,12 @@ import {
   Alert,
   Anchor,
   Button,
+  Divider,
   Flex,
   Group,
   Loader,
   Stack,
+  Switch,
   Table,
   TagsInput,
   Text,
@@ -29,6 +31,7 @@ import { Avatars } from "@/components/avatars/Avatars.tsx";
 import { ContentWrapper } from "@/components/layout/ContentWrapper/ContentWrapper.tsx";
 import { Modals, openDeleteConfirmModal } from "@/components/modals/modals.ts";
 import { ResetProjectModalFormValues } from "@/components/modals/ResetProjectModal/ResetProjectModal.tsx";
+import { DEFAULT_PROJECT_SETTINGS } from "@/lib/constants/generic.ts";
 import { useProject } from "@/lib/operators/useProject";
 import { useProjects } from "@/lib/operators/useProjects";
 import { TCollaborator } from "@/types/schema.ts";
@@ -41,6 +44,8 @@ export function Settings() {
   const navigate = useNavigate();
   const [tags, setTags] = useState<string[]>([]);
   const [collaborators, setCollaborators] = useState<TCollaborator[]>([]);
+
+  const settings = useMemo(() => project.getSettings(), [project]);
 
   useEffect(() => {
     if (project.data?.allTags) {
@@ -96,6 +101,15 @@ export function Settings() {
     });
   }, [project]);
 
+  const enableUpdateStatusDialogChangeHandler = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      project.updateSettings({
+        enableUpdateStatusDialog: event.currentTarget.checked,
+      });
+    },
+    [project]
+  );
+
   if (project.loading) {
     return (
       <Flex align="center" justify="center" h="100dvh" w="100%">
@@ -107,16 +121,30 @@ export function Settings() {
   return (
     <ContentWrapper>
       <Stack className={classes.settings} w="100%">
-        <Stack>
-          <Title order={3}>Settings</Title>
-        </Stack>
+        <Title order={3}>Settings</Title>
 
         <Stack>
-          <Title order={4}>Project data</Title>
+          <Title order={4}>Project Settings</Title>
+
+          <Stack>
+            <Switch
+              checked={
+                settings?.enableUpdateStatusDialog ??
+                DEFAULT_PROJECT_SETTINGS.enableUpdateStatusDialog
+              }
+              label="Enable Update Status dialog"
+              description="When this setting is enabled, during a status update you will have to assign the test to a collaborator, and you could add some extra notes about the change updates"
+              onChange={enableUpdateStatusDialogChangeHandler}
+            ></Switch>
+          </Stack>
         </Stack>
+
+        <Divider />
+
+        <Title order={4}>Project data</Title>
 
         <Stack gap="md">
-          <Title order={4}>Collaborators</Title>
+          <Title order={5}>Collaborators</Title>
           {collaborators.length === 0 ? (
             <Text span>
               The list is empty. Do you want to{" "}
@@ -215,11 +243,10 @@ export function Settings() {
         </Stack>
 
         <Stack>
-          <Title order={4}>Tags</Title>
+          <Title order={5}>Tags</Title>
           <TagsInput data={[]} value={tags} onChange={setTags} />
           <Group justify="end">
             <Button
-              w={105}
               leftSection={<IconDeviceFloppy size={18} />}
               onClick={() => {
                 project.updateAllTags(tags);
@@ -231,7 +258,7 @@ export function Settings() {
                 });
               }}
             >
-              Save
+              Save Tags
             </Button>
           </Group>
         </Stack>

--- a/src/components/statusMenu/StatusMenu.tsx
+++ b/src/components/statusMenu/StatusMenu.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
 import { useParams } from "react-router";
 import { Group, Text } from "@mantine/core";
 import { modals } from "@mantine/modals";
@@ -21,25 +21,30 @@ type TProps = {
 export function StatusMenu({ id, step, target, updateStepStatuses }: TProps) {
   const params = useParams();
   const project = useProject(params.projectId);
+  const projectSettings = useMemo(() => project.getSettings(), [project]);
 
   const onStatusChange = (status: StatusEnum) => {
-    modals.openContextModal({
-      modal: Modals.ChangeStatusModal,
-      title: (
-        <Group wrap="nowrap" gap={6}>
-          Update Status to{" "}
-          <Group gap={6} wrap="nowrap">
-            <StatusIcon status={status} showTooltip={false} />
-            <Text span>{getStatusLabel(status)}</Text>
+    if (projectSettings?.enableUpdateStatusDialog === true) {
+      modals.openContextModal({
+        modal: Modals.ChangeStatusModal,
+        title: (
+          <Group wrap="nowrap" gap={6}>
+            Update Status to{" "}
+            <Group gap={6} wrap="nowrap">
+              <StatusIcon status={status} showTooltip={false} />
+              <Text span>{getStatusLabel(status)}</Text>
+            </Group>
           </Group>
-        </Group>
-      ),
-      centered: true,
-      innerProps: {
-        project,
-        handleSubmit: handleStatusChange(status),
-      },
-    });
+        ),
+        centered: true,
+        innerProps: {
+          project,
+          handleSubmit: handleStatusChange(status),
+        },
+      });
+    } else {
+      updateStepStatuses([id], status);
+    }
   };
 
   const handleStatusChange =

--- a/src/components/statusMenu/StatusMenuDropdown.tsx
+++ b/src/components/statusMenu/StatusMenuDropdown.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { MouseEvent } from "react";
 import { Box, Button, Image, Menu, Text } from "@mantine/core";
 import ArrowDropdown from "@/assets/icons/arrow_drop_down.svg";
 import { StatusIcon } from "@/components/statusIcon/StatusIcon";
@@ -19,6 +19,12 @@ export const StatusMenuDropdown = ({
 }: StatusMenuDropdownProps) => {
   const statusColor = getStatusColor(currentStatus);
   const statusLabel = getStatusLabel(currentStatus);
+
+  const clickHandler = (event: MouseEvent<HTMLButtonElement>) => {
+    // Prevent a click on the status button from propagating to parent elements,
+    // switching to the step detail view.
+    event.stopPropagation();
+  };
 
   return (
     <Menu shadow="md" width={200}>
@@ -43,6 +49,7 @@ export const StatusMenuDropdown = ({
                 />
               </Box>
             }
+            onClick={clickHandler}
           >
             <Box hiddenFrom="md">
               <StatusIcon status={currentStatus} />

--- a/src/components/stepDetails/stepDetails.tsx
+++ b/src/components/stepDetails/stepDetails.tsx
@@ -44,6 +44,8 @@ export const StepDetails = () => {
     params.stepId
   );
 
+  const projectSettings = useMemo(() => project.getSettings(), [project]);
+
   const comments: StepTimelineComment[] = useMemo(
     () =>
       testCase?.data?.comments
@@ -111,23 +113,28 @@ export const StepDetails = () => {
   };
 
   const onStatusChange = (status: StatusEnum) => {
-    modals.openContextModal({
-      modal: Modals.ChangeStatusModal,
-      title: (
-        <Group wrap="nowrap" gap={6}>
-          Update Status to{" "}
-          <Group gap={6} wrap="nowrap">
-            <StatusIcon status={status} showTooltip={false} />
-            <Text span>{getStatusLabel(status)}</Text>
+    if (projectSettings?.enableUpdateStatusDialog === true) {
+      modals.openContextModal({
+        modal: Modals.ChangeStatusModal,
+        title: (
+          <Group wrap="nowrap" gap={6}>
+            Update Status to{" "}
+            <Group gap={6} wrap="nowrap">
+              <StatusIcon status={status} showTooltip={false} />
+              <Text span>{getStatusLabel(status)}</Text>
+            </Group>
           </Group>
-        </Group>
-      ),
-      centered: true,
-      innerProps: {
-        project,
-        handleSubmit: handleStatusChange(status),
-      },
-    });
+        ),
+        centered: true,
+        innerProps: {
+          project,
+          handleSubmit: handleStatusChange(status),
+        },
+      });
+    } else {
+      // just update the status without asking for more info
+      test.updateStepStatuses([step.data.id], status);
+    }
   };
 
   const handleStatusChange =

--- a/src/lib/constants/generic.ts
+++ b/src/lib/constants/generic.ts
@@ -1,4 +1,4 @@
-import { TCollaborator } from "@/types/schema.ts";
+import { TCollaborator, TProjectSettings } from "@/types/schema.ts";
 
 export const USER_ANONYMOUS: TCollaborator = {
   id: "Anonymous",
@@ -13,3 +13,7 @@ export const IMAGE_INSERT_ALLOWED_MIME_TYPES = ["image/*"]; // all images
 export const IMAGE_INSERT_COMPRESSION_QUALITY = 0.6;
 export const IMAGE_INSERT_RESIZE_MAX_WIDTH = 600;
 export const IMAGE_INSERT_RESIZE_MAX_HEIGHT = 400;
+
+export const DEFAULT_PROJECT_SETTINGS: TProjectSettings = {
+  enableUpdateStatusDialog: false,
+};

--- a/src/lib/operators/types.ts
+++ b/src/lib/operators/types.ts
@@ -8,6 +8,7 @@ import {
   TDocType,
   TProject,
   TProjectDynamicData,
+  TProjectSettings,
   TStatusChange,
   TStep,
   TStepDynamicData,
@@ -52,6 +53,7 @@ export type TUseProject = {
   getTagsByCaseId: (caseId: TCase["id"]) => string[];
   getAssigneesByTestId: (testId: TTest["id"]) => TCollaborator[];
   getAssigneesByCaseId: (caseId: TCase["id"]) => TCollaborator[];
+  getSettings: () => undefined | TProjectSettings;
   getStatusChangesByStepId: (stepId: TStep["id"]) => TStatusChange[];
   getTestsByTags: () => Record<string, TTest[]>;
   getCollaborator: (
@@ -76,6 +78,7 @@ export type TUseProject = {
   updateProject: (
     data: Partial<Pick<TProject, "title" | "customer" | "description">>
   ) => void;
+  updateSettings: (settings: Partial<TProjectSettings>) => void;
 } & TOperatorLoader<TProject>;
 
 export type TUseTestCase = {

--- a/src/lib/operators/useProject.ts
+++ b/src/lib/operators/useProject.ts
@@ -2,11 +2,12 @@ import { useCallback, useMemo } from "react";
 import { useDocument } from "@automerge/automerge-repo-react-hooks";
 import slugify from "slugify";
 import { useDocContext } from "@/components/docContext/hooks/useDocContext.ts";
+import { DEFAULT_PROJECT_SETTINGS } from "@/lib/constants/generic.ts";
 import { STORAGE_KEYS } from "@/lib/constants/localStorageKeys";
 import { downloadFile } from "@/lib/helpers/downloadFile";
 import { removeTuples } from "@/lib/helpers/removeTuples";
 import { TJsonExport } from "@/types/json-export";
-import { StatusEnum, TDocType, TTest } from "@/types/schema";
+import { StatusEnum, TDocType, TProjectSettings, TTest } from "@/types/schema";
 import { TOperatorLoaderStatus, TUseProject } from "./types";
 
 export function useProject(projectId: string | undefined): TUseProject {
@@ -509,12 +510,58 @@ export function useProject(projectId: string | undefined): TUseProject {
     [changeDoc, projectId]
   );
 
+  const getSettings: TUseProject["getSettings"] = useCallback(() => {
+    if (!projectId) {
+      return;
+    }
+
+    const project = doc?.projects.find(
+      (item) => projectId && item.id === projectId
+    );
+
+    if (!project) {
+      return;
+    }
+
+    return project?.settings ?? DEFAULT_PROJECT_SETTINGS;
+  }, [doc?.projects, projectId]);
+
+  const updateSettings: TUseProject["updateSettings"] = useCallback(
+    (newSettings: Partial<TProjectSettings>) => {
+      if (!newSettings) {
+        return;
+      }
+
+      if (!projectId) {
+        return;
+      }
+
+      changeDoc((doc) => {
+        const project = doc.projects.find(
+          (item) => projectId && item.id === projectId
+        );
+        if (!project) {
+          return;
+        }
+
+        const activeSettings = project.settings || {};
+
+        project.settings = {
+          ...activeSettings,
+          ...newSettings,
+        };
+      });
+    },
+    [changeDoc, projectId]
+  );
+
   const methods = useMemo(
     () => ({
       getTagsByTestId,
       getTagsByCaseId,
       getAssigneesByTestId,
       getAssigneesByCaseId,
+      getSettings,
       getStatusChangesByStepId,
       getCollaborator,
       exportJSON,
@@ -527,6 +574,7 @@ export function useProject(projectId: string | undefined): TUseProject {
       removeCollaborator,
       removeTestCase,
       updateProject,
+      updateSettings,
       getTestsByTags,
       resetProject,
     }),
@@ -537,6 +585,7 @@ export function useProject(projectId: string | undefined): TUseProject {
       getAssigneesByCaseId,
       getAssigneesByTestId,
       getCollaborator,
+      getSettings,
       getStatusChangesByStepId,
       getTagsByCaseId,
       getTagsByTestId,
@@ -547,6 +596,7 @@ export function useProject(projectId: string | undefined): TUseProject {
       updateProject,
       updateTestCase,
       updateTestCaseStatus,
+      updateSettings,
       getTestsByTags,
       resetProject,
     ]

--- a/src/lib/operators/useTest.ts
+++ b/src/lib/operators/useTest.ts
@@ -93,8 +93,8 @@ export function useTest(
             stepId: step.id,
             targetStatus: status,
             testId,
-            collaboratorId,
-            notes,
+            collaboratorId: collaboratorId ?? null,
+            notes: notes ?? null,
           });
         });
       });

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -116,6 +116,6 @@ export type TStatusChange = {
   createdAt: number;
   targetStatus?: StatusEnum;
   previousStatus?: StatusEnum;
-  collaboratorId?: string;
-  notes?: string;
+  collaboratorId: string | null;
+  notes: string | null;
 };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -77,10 +77,15 @@ export type TCollaborator = {
   createdAt: number;
 } & TCollaboratorDynamicData;
 
+export type TProjectSettings = {
+  enableUpdateStatusDialog?: boolean;
+};
+
 export type TProjectDynamicData = {
   title: string;
   customer: string;
   lastUpdate?: number;
+  settings?: TProjectSettings;
 };
 
 export type TProject = {


### PR DESCRIPTION
Closes #184 

Adds `getSettings` and `updateSettings` to `useProject` hook, used to store a new `setting` record of type `TProjectSetting`.

When `project.setting.enableUpdateStatusDialog` is `false` (which is also the default value), it will skip  the `Modals.ChangeStatusModal`, passing the `null` value to `collaboratorId` and `notes`.

Type of collaboratorId and notes was changed from undefined to null to avoid this error: 

```
Uncaught RangeError: Cannot assign undefined value at /projects/3/statusChanges/3/collaboratorId, 
because `undefined` is not a valid JSON data type. You might consider setting the property's 
value to `null`, or using `delete` to remove it altogether.
```